### PR TITLE
Allow interpolation in selector literals

### DIFF
--- a/examples/ast/beet.yml
+++ b/examples/ast/beet.yml
@@ -1,0 +1,13 @@
+data_pack:
+  load:
+    - data/test/functions/foo.mcfunction: ./foo.mcfunction
+
+pipeline:
+  - mecha
+
+require:
+  - bolt
+  - bolt_selectors
+  - mecha.contrib.debug_ast
+
+output: .build 

--- a/examples/ast/foo.mcfunction
+++ b/examples/ast/foo.mcfunction
@@ -1,0 +1,55 @@
+
+# this should not be affected
+if entity @e[type=armor_stand]
+
+entity = "minecraft:zombie"
+dist = 5
+
+self = @s[
+    x=0,
+    y=0,
+    z=0,
+
+    distance=(None, dist),
+
+    dx=1,
+    dy=1,
+    dz=1,
+
+    x_rotation=..90,
+    y_rotation=90..,
+
+    scores={foo=1,bar=..1,baz=1..},
+
+    tag=foo.bar.baz,
+    tag=!foo.baz.bar,
+
+    team=fooBar,
+    team=!fooBaz,
+
+    name=BazBarFoo,
+    name=!BarFooBaz,
+
+    type=entity,
+    type=!skeleton,
+
+    predicate=./foo,
+    predicate=!./bar,
+
+    nbt={Health:20f},
+    nbt=!{Health:19f},
+
+    level=1..,
+    gamemode=!adventure,
+    gamemode=!survival,
+    advancements={
+        ./foo=true,
+        ./bar={baz=true}
+    },
+
+    limit=1,
+    sort=nearest
+]
+
+give self stick
+

--- a/examples/codegen/beet.yml
+++ b/examples/codegen/beet.yml
@@ -1,0 +1,13 @@
+data_pack:
+  load:
+    - data/test/functions/foo.mcfunction: ./foo.mcfunction
+
+pipeline:
+  - mecha
+
+require:
+  - bolt
+  - bolt_selectors
+  - bolt.contrib.debug_codegen
+
+output: .build 

--- a/examples/codegen/foo.mcfunction
+++ b/examples/codegen/foo.mcfunction
@@ -1,0 +1,55 @@
+
+# this should not be affected
+if entity @e[type=armor_stand]
+
+entity = "minecraft:zombie"
+dist = 5
+
+self = @s[
+    x=0,
+    y=0,
+    z=0,
+
+    distance=(None, dist),
+
+    dx=1,
+    dy=1,
+    dz=1,
+
+    x_rotation=..90,
+    y_rotation=90..,
+
+    scores={foo=1,bar=..1,baz=1..},
+
+    tag=foo.bar.baz,
+    tag=!foo.baz.bar,
+
+    team=fooBar,
+    team=!fooBaz,
+
+    name=BazBarFoo,
+    name=!BarFooBaz,
+
+    type=entity,
+    type=!skeleton,
+
+    predicate=./foo,
+    predicate=!./bar,
+
+    nbt={Health:20f},
+    nbt=!{Health:19f},
+
+    level=1..,
+    gamemode=!adventure,
+    gamemode=!survival,
+    advancements={
+        ./foo=true,
+        ./bar={baz=true}
+    },
+
+    limit=1,
+    sort=nearest
+]
+
+give self stick
+

--- a/examples/interpolation/beet.yml
+++ b/examples/interpolation/beet.yml
@@ -1,0 +1,16 @@
+data_pack:
+  load:
+    - data/test/modules/entry.bolt: ./entry.bolt
+
+pipeline:
+  - mecha
+
+require:
+  - bolt
+  - bolt_selectors
+
+output: .build 
+
+meta:
+  bolt:
+    entrypoint: test:entry

--- a/examples/interpolation/entry.bolt
+++ b/examples/interpolation/entry.bolt
@@ -1,0 +1,9 @@
+function test:foo:
+    self = @s
+    tellraw self "hi"
+
+    prefix = "foobar"
+
+    cows = @e[type=minecraft:cow,tag=(prefix + ".test")]
+    kill cows
+

--- a/tests/snapshots/examples__build_ast__0.pack.md
+++ b/tests/snapshots/examples__build_ast__0.pack.md
@@ -1,0 +1,409 @@
+# Lectern snapshot
+
+## Data pack
+
+`@data_pack pack.mcmeta`
+
+```json
+{
+  "pack": {
+    "pack_format": 61,
+    "description": ""
+  }
+}
+```
+
+### test
+
+`@function test:foo`
+
+```mcfunction
+<class 'mecha.ast.AstRoot'>
+  commands:
+    <class 'mecha.ast.AstCommand'>
+      identifier: 'execute:subcommand'
+      arguments:
+        <class 'mecha.ast.AstCommand'>
+          identifier: 'execute:if:entity:entities'
+          arguments:
+            <class 'mecha.ast.AstSelector'>
+              variable: 'e'
+              arguments:
+                <class 'mecha.ast.AstSelectorArgument'>
+                  inverted: False
+                  key:
+                    <class 'mecha.ast.AstString'>
+                      value: 'type'
+                  value:
+                    <class 'mecha.ast.AstResourceLocation'>
+                      is_tag: False
+                      namespace: None
+                      path: 'armor_stand'
+    <class 'bolt.ast.AstStatement'>
+      identifier: 'mecha:sentinel'
+      arguments:
+        <class 'bolt.ast.AstAssignment'>
+          operator: '='
+          target:
+            <class 'bolt.ast.AstTargetIdentifier'>
+              value: 'entity'
+              rebind: False
+          value:
+            <class 'bolt.ast.AstValue'>
+              value: 'minecraft:zombie'
+          type_annotation: None
+    <class 'bolt.ast.AstStatement'>
+      identifier: 'mecha:sentinel'
+      arguments:
+        <class 'bolt.ast.AstAssignment'>
+          operator: '='
+          target:
+            <class 'bolt.ast.AstTargetIdentifier'>
+              value: 'dist'
+              rebind: False
+          value:
+            <class 'bolt.ast.AstValue'>
+              value: 5
+          type_annotation: None
+    <class 'bolt.ast.AstStatement'>
+      identifier: 'mecha:sentinel'
+      arguments:
+        <class 'bolt.ast.AstAssignment'>
+          operator: '='
+          target:
+            <class 'bolt.ast.AstTargetIdentifier'>
+              value: 'self'
+              rebind: False
+          value:
+            <class 'bolt_selectors.plugin.AstSelectorLiteral'>
+              variable: 's'
+              arguments:
+                <class 'mecha.ast.AstSelectorArgument'>
+                  inverted: False
+                  key:
+                    <class 'mecha.ast.AstString'>
+                      value: 'x'
+                  value:
+                    <class 'mecha.ast.AstNumber'>
+                      value: 0
+                <class 'mecha.ast.AstSelectorArgument'>
+                  inverted: False
+                  key:
+                    <class 'mecha.ast.AstString'>
+                      value: 'y'
+                  value:
+                    <class 'mecha.ast.AstNumber'>
+                      value: 0
+                <class 'mecha.ast.AstSelectorArgument'>
+                  inverted: False
+                  key:
+                    <class 'mecha.ast.AstString'>
+                      value: 'z'
+                  value:
+                    <class 'mecha.ast.AstNumber'>
+                      value: 0
+                <class 'mecha.ast.AstSelectorArgument'>
+                  inverted: False
+                  key:
+                    <class 'mecha.ast.AstString'>
+                      value: 'distance'
+                  value:
+                    <class 'bolt.ast.AstInterpolation'>
+                      prefix: None
+                      unpack: None
+                      converter: 'range'
+                      value:
+                        <class 'bolt.ast.AstTuple'>
+                          items:
+                            <class 'bolt.ast.AstValue'>
+                              value: None
+                            <class 'bolt.ast.AstIdentifier'>
+                              value: 'dist'
+                <class 'mecha.ast.AstSelectorArgument'>
+                  inverted: False
+                  key:
+                    <class 'mecha.ast.AstString'>
+                      value: 'dx'
+                  value:
+                    <class 'mecha.ast.AstNumber'>
+                      value: 1
+                <class 'mecha.ast.AstSelectorArgument'>
+                  inverted: False
+                  key:
+                    <class 'mecha.ast.AstString'>
+                      value: 'dy'
+                  value:
+                    <class 'mecha.ast.AstNumber'>
+                      value: 1
+                <class 'mecha.ast.AstSelectorArgument'>
+                  inverted: False
+                  key:
+                    <class 'mecha.ast.AstString'>
+                      value: 'dz'
+                  value:
+                    <class 'mecha.ast.AstNumber'>
+                      value: 1
+                <class 'mecha.ast.AstSelectorArgument'>
+                  inverted: False
+                  key:
+                    <class 'mecha.ast.AstString'>
+                      value: 'x_rotation'
+                  value:
+                    <class 'mecha.ast.AstRange'>
+                      min: None
+                      max: 90
+                <class 'mecha.ast.AstSelectorArgument'>
+                  inverted: False
+                  key:
+                    <class 'mecha.ast.AstString'>
+                      value: 'y_rotation'
+                  value:
+                    <class 'mecha.ast.AstRange'>
+                      min: 90
+                      max: None
+                <class 'mecha.ast.AstSelectorArgument'>
+                  inverted: False
+                  key:
+                    <class 'mecha.ast.AstString'>
+                      value: 'scores'
+                  value:
+                    <class 'mecha.ast.AstSelectorScores'>
+                      scores:
+                        <class 'mecha.ast.AstSelectorScoreMatch'>
+                          key:
+                            <class 'mecha.ast.AstObjective'>
+                              value: 'foo'
+                          value:
+                            <class 'mecha.ast.AstRange'>
+                              min: 1
+                              max: 1
+                        <class 'mecha.ast.AstSelectorScoreMatch'>
+                          key:
+                            <class 'mecha.ast.AstObjective'>
+                              value: 'bar'
+                          value:
+                            <class 'mecha.ast.AstRange'>
+                              min: None
+                              max: 1
+                        <class 'mecha.ast.AstSelectorScoreMatch'>
+                          key:
+                            <class 'mecha.ast.AstObjective'>
+                              value: 'baz'
+                          value:
+                            <class 'mecha.ast.AstRange'>
+                              min: 1
+                              max: None
+                <class 'mecha.ast.AstSelectorArgument'>
+                  inverted: False
+                  key:
+                    <class 'mecha.ast.AstString'>
+                      value: 'tag'
+                  value:
+                    <class 'mecha.ast.AstWord'>
+                      value: 'foo.bar.baz'
+                <class 'mecha.ast.AstSelectorArgument'>
+                  inverted: True
+                  key:
+                    <class 'mecha.ast.AstString'>
+                      value: 'tag'
+                  value:
+                    <class 'mecha.ast.AstWord'>
+                      value: 'foo.baz.bar'
+                <class 'mecha.ast.AstSelectorArgument'>
+                  inverted: False
+                  key:
+                    <class 'mecha.ast.AstString'>
+                      value: 'team'
+                  value:
+                    <class 'mecha.ast.AstTeam'>
+                      value: 'fooBar'
+                <class 'mecha.ast.AstSelectorArgument'>
+                  inverted: True
+                  key:
+                    <class 'mecha.ast.AstString'>
+                      value: 'team'
+                  value:
+                    <class 'mecha.ast.AstTeam'>
+                      value: 'fooBaz'
+                <class 'mecha.ast.AstSelectorArgument'>
+                  inverted: False
+                  key:
+                    <class 'mecha.ast.AstString'>
+                      value: 'name'
+                  value:
+                    <class 'mecha.ast.AstString'>
+                      value: 'BazBarFoo'
+                <class 'mecha.ast.AstSelectorArgument'>
+                  inverted: True
+                  key:
+                    <class 'mecha.ast.AstString'>
+                      value: 'name'
+                  value:
+                    <class 'mecha.ast.AstString'>
+                      value: 'BarFooBaz'
+                <class 'mecha.ast.AstSelectorArgument'>
+                  inverted: False
+                  key:
+                    <class 'mecha.ast.AstString'>
+                      value: 'type'
+                  value:
+                    <class 'bolt.ast.AstInterpolation'>
+                      prefix: None
+                      unpack: None
+                      converter: 'resource_location'
+                      value:
+                        <class 'bolt.ast.AstIdentifier'>
+                          value: 'entity'
+                <class 'mecha.ast.AstSelectorArgument'>
+                  inverted: True
+                  key:
+                    <class 'mecha.ast.AstString'>
+                      value: 'type'
+                  value:
+                    <class 'mecha.ast.AstResourceLocation'>
+                      is_tag: False
+                      namespace: None
+                      path: 'skeleton'
+                <class 'mecha.ast.AstSelectorArgument'>
+                  inverted: False
+                  key:
+                    <class 'mecha.ast.AstString'>
+                      value: 'predicate'
+                  value:
+                    <class 'mecha.ast.AstResourceLocation'>
+                      is_tag: False
+                      namespace: 'test'
+                      path: 'foo'
+                <class 'mecha.ast.AstSelectorArgument'>
+                  inverted: True
+                  key:
+                    <class 'mecha.ast.AstString'>
+                      value: 'predicate'
+                  value:
+                    <class 'mecha.ast.AstResourceLocation'>
+                      is_tag: False
+                      namespace: 'test'
+                      path: 'bar'
+                <class 'mecha.ast.AstSelectorArgument'>
+                  inverted: False
+                  key:
+                    <class 'mecha.ast.AstString'>
+                      value: 'nbt'
+                  value:
+                    <class 'mecha.ast.AstNbtCompound'>
+                      entries:
+                        <class 'mecha.ast.AstNbtCompoundEntry'>
+                          key:
+                            <class 'mecha.ast.AstNbtCompoundKey'>
+                              value: 'Health'
+                          value:
+                            <class 'mecha.ast.AstNbtValue'>
+                              value: Float(20.0)
+                <class 'mecha.ast.AstSelectorArgument'>
+                  inverted: True
+                  key:
+                    <class 'mecha.ast.AstString'>
+                      value: 'nbt'
+                  value:
+                    <class 'mecha.ast.AstNbtCompound'>
+                      entries:
+                        <class 'mecha.ast.AstNbtCompoundEntry'>
+                          key:
+                            <class 'mecha.ast.AstNbtCompoundKey'>
+                              value: 'Health'
+                          value:
+                            <class 'mecha.ast.AstNbtValue'>
+                              value: Float(19.0)
+                <class 'mecha.ast.AstSelectorArgument'>
+                  inverted: False
+                  key:
+                    <class 'mecha.ast.AstString'>
+                      value: 'level'
+                  value:
+                    <class 'mecha.ast.AstRange'>
+                      min: 1
+                      max: None
+                <class 'mecha.ast.AstSelectorArgument'>
+                  inverted: True
+                  key:
+                    <class 'mecha.ast.AstString'>
+                      value: 'gamemode'
+                  value:
+                    <class 'mecha.ast.AstGamemode'>
+                      value: 'adventure'
+                <class 'mecha.ast.AstSelectorArgument'>
+                  inverted: True
+                  key:
+                    <class 'mecha.ast.AstString'>
+                      value: 'gamemode'
+                  value:
+                    <class 'mecha.ast.AstGamemode'>
+                      value: 'survival'
+                <class 'mecha.ast.AstSelectorArgument'>
+                  inverted: False
+                  key:
+                    <class 'mecha.ast.AstString'>
+                      value: 'advancements'
+                  value:
+                    <class 'mecha.ast.AstSelectorAdvancements'>
+                      advancements:
+                        <class 'mecha.ast.AstSelectorAdvancementMatch'>
+                          key:
+                            <class 'mecha.ast.AstResourceLocation'>
+                              is_tag: False
+                              namespace: 'test'
+                              path: 'foo'
+                          value:
+                            <class 'mecha.ast.AstBool'>
+                              value: True
+                        <class 'mecha.ast.AstSelectorAdvancementMatch'>
+                          key:
+                            <class 'mecha.ast.AstResourceLocation'>
+                              is_tag: False
+                              namespace: 'test'
+                              path: 'bar'
+                          value:
+                            <class 'mecha.ast.AstSelectorAdvancementPredicateMatch'>
+                              key:
+                                <class 'mecha.ast.AstAdvancementPredicate'>
+                                  value: 'baz'
+                              value:
+                                <class 'mecha.ast.AstBool'>
+                                  value: True
+                <class 'mecha.ast.AstSelectorArgument'>
+                  inverted: False
+                  key:
+                    <class 'mecha.ast.AstString'>
+                      value: 'limit'
+                  value:
+                    <class 'mecha.ast.AstNumber'>
+                      value: 1
+                <class 'mecha.ast.AstSelectorArgument'>
+                  inverted: False
+                  key:
+                    <class 'mecha.ast.AstString'>
+                      value: 'sort'
+                  value:
+                    <class 'mecha.ast.AstSortOrder'>
+                      value: 'nearest'
+          type_annotation: None
+    <class 'mecha.ast.AstCommand'>
+      identifier: 'give:targets:item'
+      arguments:
+        <class 'bolt.ast.AstInterpolation'>
+          prefix: None
+          unpack: None
+          converter: 'entity'
+          value:
+            <class 'bolt.ast.AstIdentifier'>
+              value: 'self'
+        <class 'mecha.ast.AstItemStack'>
+          identifier:
+            <class 'mecha.ast.AstResourceLocation'>
+              is_tag: False
+              namespace: None
+              path: 'stick'
+          arguments:
+            <empty>
+          data_tags: None
+```

--- a/tests/snapshots/examples__build_codegen__0.pack.md
+++ b/tests/snapshots/examples__build_codegen__0.pack.md
@@ -1,0 +1,45 @@
+# Lectern snapshot
+
+## Data pack
+
+`@data_pack pack.mcmeta`
+
+```json
+{
+  "pack": {
+    "pack_format": 61,
+    "description": ""
+  }
+}
+```
+
+### test
+
+`@function test:foo`
+
+```mcfunction
+_bolt_lineno = [1, 11, 13, 15, 18, 20, 21], [1, 5, 6, 13, 33, 8, 54]
+_bolt_helper_interpolate_range = _bolt_runtime.helpers['interpolate_range']
+_bolt_helper_replace = _bolt_runtime.helpers['replace']
+_bolt_helper_interpolate_resource_location = _bolt_runtime.helpers['interpolate_resource_location']
+_bolt_helper_children = _bolt_runtime.helpers['children']
+_bolt_helper_ast_to_selector = _bolt_runtime.helpers['ast_to_selector']
+_bolt_helper_interpolate_entity = _bolt_runtime.helpers['interpolate_entity']
+with _bolt_runtime.scope() as _bolt_var7:
+    _bolt_runtime.commands.append(_bolt_refs[0])
+    _bolt_var0 = 'minecraft:zombie'
+    entity = _bolt_var0
+    _bolt_var1 = 5
+    dist = _bolt_var1
+    _bolt_var2 = None
+    _bolt_var3 = dist
+    _bolt_var4 = (_bolt_var2,_bolt_var3,)
+    _bolt_var4 = _bolt_helper_interpolate_range(_bolt_var4, _bolt_refs[1])
+    _bolt_var5 = entity
+    _bolt_var5 = _bolt_helper_interpolate_resource_location(_bolt_var5, _bolt_refs[6])
+    self = _bolt_helper_ast_to_selector(_bolt_helper_replace(_bolt_refs[31], arguments=_bolt_helper_children([_bolt_refs[3], _bolt_refs[4], _bolt_refs[5], _bolt_helper_replace(_bolt_refs[2], value=_bolt_var4), _bolt_refs[8], _bolt_refs[9], _bolt_refs[10], _bolt_refs[11], _bolt_refs[12], _bolt_refs[13], _bolt_refs[14], _bolt_refs[15], _bolt_refs[16], _bolt_refs[17], _bolt_refs[18], _bolt_refs[19], _bolt_helper_replace(_bolt_refs[7], value=_bolt_var5), _bolt_refs[20], _bolt_refs[21], _bolt_refs[22], _bolt_refs[23], _bolt_refs[24], _bolt_refs[25], _bolt_refs[26], _bolt_refs[27], _bolt_refs[28], _bolt_refs[29], _bolt_refs[30]])))
+    _bolt_var6 = self
+    _bolt_var6 = _bolt_helper_interpolate_entity(_bolt_var6, _bolt_refs[32])
+    _bolt_runtime.commands.append(_bolt_helper_replace(_bolt_refs[34], arguments=_bolt_helper_children([_bolt_var6, _bolt_refs[33]])))
+_bolt_var8 = _bolt_helper_replace(_bolt_refs[35], commands=_bolt_helper_children(_bolt_var7))
+```

--- a/tests/snapshots/examples__build_interpolation__0.pack.md
+++ b/tests/snapshots/examples__build_interpolation__0.pack.md
@@ -1,0 +1,23 @@
+# Lectern snapshot
+
+## Data pack
+
+`@data_pack pack.mcmeta`
+
+```json
+{
+  "pack": {
+    "pack_format": 61,
+    "description": ""
+  }
+}
+```
+
+### test
+
+`@function test:foo`
+
+```mcfunction
+tellraw @s "hi"
+kill @e[tag=foobar.test, type=minecraft:cow]
+```


### PR DESCRIPTION
Hey!

I just fixed some things in this plugin. Instead of wrapping Selector objects in AstValue nodes, it's better to generate special ast (AstSelectorLiteral nodes) that later on are converted to Selector objects (with the codegen).

I also added three tests for testing interpolation, debugging the ast and the codegen.